### PR TITLE
SMD-MDB-CA.LS listSessions soundness

### DIFF
--- a/src/main/scala/group/scala/karazin/mongo4s/model.scala
+++ b/src/main/scala/group/scala/karazin/mongo4s/model.scala
@@ -248,10 +248,13 @@ object model:
     final case class Limit($limit: Int)
 
     object ListSessions:
-      final case class User(user: String, db: String)
 
-      final case class Command(users: Option[List[User]],
-                               allUsers: Option[Boolean])
+      type Command = EmptyObject | Users | AllUsers
+
+      final case class User(user: String, db: String)
+      final case class Users(users: List[User])
+      final case class AllUsers(allUsers: Boolean)
+
     end ListSessions
     final case class ListSessions($listSessions: ListSessions.Command)
 


### PR DESCRIPTION
The $listSessions stage takes a document with one of the following contents:
* { }
* { users: [ { user: <user>, db: <db> }, ... ] }
* { allUsers: true }